### PR TITLE
Delete duplicate wg-quick@ entry

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
       set -o errexit
       set -o pipefail
       set -o nounset
-      systemctl is-active wg-quick@wg-quick@{{ wireguard_interface|quote }} || systemctl start wg-quick@{{ wireguard_interface|quote }}
+      systemctl is-active wg-quick@{{ wireguard_interface|quote }} || systemctl start wg-quick@{{ wireguard_interface|quote }}
       wg syncconf {{ wireguard_interface|quote }} <(wg-quick strip /etc/wireguard/{{ wireguard_interface|quote }}.conf)
       exit 0
   args:


### PR DESCRIPTION
This resulted in `inactive` by `systemctl is-active` at all times. If corrected it actually has a chance to return `active` status if it is active - as it is now, the handler will always fail